### PR TITLE
Add API endpoint and unit tests for stats page

### DIFF
--- a/src/app/api/items.py
+++ b/src/app/api/items.py
@@ -39,3 +39,17 @@ def ingredients_for_item(game_id: int, item_id: int):
         return jsonify({"error": "Item not found"}), 404
     
     return jsonify(result)
+
+@bp.route('/games/<int:game_id>/stats', methods=['GET'])
+def minmax_ingredients(game_id: int):
+    game_data = GameService.load_game_data(game_id)
+    if not game_data:
+        return jsonify({"error": "Game not found or failed to load data"}), 404
+
+    graph = game_data.item_graph
+    result = {
+        "min": graph.min_ingredient_amount(),
+        "max": graph.max_ingredient_amount()
+    }
+
+    return jsonify(result)

--- a/tests/api/test_stats.py
+++ b/tests/api/test_stats.py
@@ -1,0 +1,36 @@
+from typing import Dict, Any
+
+def _verify_valid_stats(stats: Dict[str, Any]):
+     """Helper function to verify stats output.
+     Verifies that the stats objects contains min and max
+     and that they are of the correct types.
+     """
+     assert set(stats.keys()) == {"min", "max"}
+     assert type(stats["min"]) is float, int
+     assert type(stats["max"]) is float, int
+
+def test_stats_get(client):
+     """This unit test checks the endpoint: `GET /api/games/<int:game_id>/stats`"""
+     r = client.get("/api/games/1/stats")
+ 
+     # Get the list of games should always succeed, i.e. HTTP 200 OK
+     assert r.status_code == 200
+ 
+     # Response type should be JSON
+     assert r.mimetype == "application/json"
+ 
+     # JSON should be parsable as a dict
+     assert isinstance(r.json, dict)
+ 
+     # Verify stats format
+     _verify_valid_stats(r.json)
+
+def test_stats_wrong_method(client):
+    """This unit test checks the endpoint: `POST /api/games/<int:game_id>/stats`
+    This method is not allowed by our API server (only GET)
+    therefore this request should fail on 
+    """
+    r = client.post("/api/games/1/stats")
+
+    # Expected response is HTTP 405 Method Not Allowed
+    assert r.status_code == 405


### PR DESCRIPTION
- [x] My code follows the style guide 
- [x] Unit tests were added
- [ ] Unit tests will be added later after some review
- [ ] Unit tests weren't necessary

Previously, there was no endpoint for a stats page in the CraftBuddy app that showed, for example, the minimum and maximum ingredient amounts. Now, an endpoint has been implemented in the `items.py` file along with the other endpoints to enable the addition of various statistics related to crafterlib and CraftBuddy. I also added unit tests for this endpoint in a file called `test_stats.py`, which follows the `test_games.py` layout very closely. 

New endpoint that was added:
/api/games/<int:game_id>/stats
