### PR TITLE
Add amount_craftable_with endpoints and unit tests

### DIFF
--- a/src/app/api/items.py
+++ b/src/app/api/items.py
@@ -39,3 +39,37 @@ def ingredients_for_item(game_id: int, item_id: int):
         return jsonify({"error": "Item not found"}), 404
     
     return jsonify(result)
+
+@bp.route('/games/<int:game_id>/items/<int:item_id>/amountCraftable',methods=['GET'])
+def amount_craftable_for_item(game_id: int, item_id: int):
+    
+    game_data = GameService.load_game_data(game_id)
+    if not game_data:
+        return jsonify({"error": "Game not found or failed to load data"}), 404
+
+    # return inventory from query parameters
+    inventory = {}
+    for key, value in request.args.items():
+        if key == "recursive":
+            continue
+        try:
+            inventory[key] = float(value)
+        except ValueError:
+            return jsonify({"error": f"Invalid quantity for {key}"}), 400
+
+    if not inventory:
+        return jsonify({"error": "No inventory provided try amountCraftable?{itemname1}={quantity1}&{itemname2}={quantity2}&recursive={true/false}"}), 400
+
+    recursive = request.args.get("recursive", "false").lower() == "true"
+
+    result = CraftingService.calculate_amount_craftable(
+        game_data=game_data,
+        item_id=item_id,
+        inventory=inventory,
+        recursive=recursive
+    )
+
+    if result is None:
+        return jsonify({"error": "Item not found"}), 404
+
+    return jsonify(result)

--- a/src/app/services/crafting_service.py
+++ b/src/app/services/crafting_service.py
@@ -42,11 +42,10 @@ class CraftingService:
     
     @staticmethod
     def calculate_amount_craftable(game_data: crafterlib.GameCraftingData, item_id: int, inventory: Dict[str, float], recursive: bool = False) -> Optional[Dict]:
-        # Get item from ID
+        # Get item from ID so we can use the item.name
         item = game_data.get_item_by_id(item_id)
         if not item:
             return None
 
         amount = crafterlib.craftutils.get_amount_craftable_with(game_data=game_data, ingredients=inventory, product=item.name, recursive=recursive)
-
         return { "item": item.name, "amount craftable": amount}

--- a/src/app/services/crafting_service.py
+++ b/src/app/services/crafting_service.py
@@ -1,5 +1,6 @@
 from typing import List, Dict, Optional
 import crafterlib
+import crafterlib.craftutils
 
 class CraftingService:
     @staticmethod
@@ -38,3 +39,14 @@ class CraftingService:
     @staticmethod
     def get_crafting_grids_for_game(game_data: crafterlib.GameCraftingData) -> List[Dict]:
         return [crafting_grid.to_dict() for crafting_grid in game_data.crafting_grids]
+    
+    @staticmethod
+    def calculate_amount_craftable(game_data: crafterlib.GameCraftingData, item_id: int, inventory: Dict[str, float], recursive: bool = False) -> Optional[Dict]:
+        # Get item from ID
+        item = game_data.get_item_by_id(item_id)
+        if not item:
+            return None
+
+        amount = crafterlib.craftutils.get_amount_craftable_with(game_data=game_data, ingredients=inventory, product=item.name, recursive=recursive)
+
+        return { "item": item.name, "amount craftable": amount}

--- a/src/wsgi.py
+++ b/src/wsgi.py
@@ -9,4 +9,4 @@ from app import create_app
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=3000, debug=True)
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/src/wsgi.py
+++ b/src/wsgi.py
@@ -9,4 +9,4 @@ from app import create_app
 app = create_app()
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8000, debug=True)
+    app.run(host="0.0.0.0", port=3000, debug=True)

--- a/tests/api/test_amount_craftable_for_item.py
+++ b/tests/api/test_amount_craftable_for_item.py
@@ -1,0 +1,43 @@
+from typing import Dict, Any
+
+def test_amount_craftable_success(client):
+    """GET amountCraftable returns correct crafting result"""
+
+    r = client.get("/api/games/1/items/203/amountCraftable?Sticks=10&Iron%20Ingot=6&recursive=true")
+
+    assert r.status_code == 200
+    assert r.mimetype == "application/json"
+    assert isinstance(r.json, dict)
+
+    assert "item" in r.json
+    assert "amount craftable" in r.json
+
+    assert r.json["item"] == "Iron Pickaxe"
+    assert r.json["amount craftable"] == 2
+
+def test_amount_craftable_missing_inventory(client):
+    """Should return 400 when no inventory is provided"""
+
+    r = client.get("/api/games/1/items/203/amountCraftable")
+
+    assert r.status_code == 400
+    assert r.mimetype == "application/json"
+    assert isinstance(r.json, dict)
+
+    assert "error" in r.json
+    assert "No inventory provided" in r.json["error"]
+
+def test_amount_craftable_invalid_item(client):
+    """Should return 404 when item does not exist"""
+
+    r = client.get(
+        "/api/games/1/items/999999/amountCraftable"
+        "?Sticks=10&Iron%20Ingot=6"
+    )
+
+    assert r.status_code == 404
+    assert r.mimetype == "application/json"
+    assert isinstance(r.json, dict)
+
+    assert "error" in r.json
+    assert r.json["error"] == "Item not found"


### PR DESCRIPTION
- [x]  My code follows the style guide
- [x] Unit tests were added
- [ ] Unit tests will be added later after some review
- [ ] Unit tests weren't necessary

Prior to this the function "get_amount_craftable_with" in crafterlib was not implemented to the backend server, so users could not use this to find out how many of a certain item, for example Iron Pickaxes, they could craft with the available ingredients in their inventories.

I solved this by creating a new GET endpoints for this feature:

/games/<int:game_id>/items/<int:item_id>/amountCraftable
Which requires query parameters, such as: ?{itemname1}={quantity1}&{itemname2}={quantity2}&recursive={true/false},
to act as the users available items. This will return how many of a certain item they can craft in a number value,
and also returns the products name to ensure you used the right item_id.

Unit tests were also added to test the endpoint.